### PR TITLE
To fix Chinese character display abnormal

### DIFF
--- a/lib/file-control.php
+++ b/lib/file-control.php
@@ -103,7 +103,10 @@ if ($_GET['action']=="load") {
 		} else {
 			$loadedFile = toUTF8noBOM(file_get_contents($file,false,$context),true);
 		}
-			echo '</script><textarea name="loadedFile" id="loadedFile">'.htmlentities($loadedFile).'</textarea><script>';
+			$encoding=ini_get("default_charset");
+			if($encoding=="")
+				$encoding="UTF-8";
+			echo '</script><textarea name="loadedFile" id="loadedFile">'.htmlentities($loadedFile,ENT_COMPAT,$encoding).'</textarea><script>';
 			// Run our custom processes
 			include_once("../processes/on-file-load.php");
 		} else if (strpos($finfo,"image")===0) {


### PR DESCRIPTION
When "default_charset" was not set in php.ini,and the file contents chinese char,it may show incorrectly.
Because the function htmlentities() takes "ISO-8859-1" as default value of "default_charset"  if PHP version is lower than 5.4.
So I think it's better to check the "default_charset" before function htmlentities().
What's your opinion?