### PR TITLE
Error control for missing local folder 

### DIFF
--- a/lib/settings-common.php
+++ b/lib/settings-common.php
@@ -185,10 +185,18 @@ function getVersionsCount($fileLoc,$fileName) {
 	global $context;
 	$count = 0;
 	$dateCounts = array();
+	$backupDateDirs = array();
 	// Establish the base, host and date dirs within...
 	$backupDirBase = str_replace("\\","/",dirname(__FILE__))."/../backups/";
 	$backupDirHost = isset($ftpSite) ? parse_url($ftpSite,PHP_URL_HOST) : "localhost";
-	$backupDateDirs = scandir($backupDirBase.$backupDirHost,1);
+        // check if folder exists if local before enumerating contents
+        if(!isset($ftpsite)) {
+                if(file_exists($backupDirBase.$backupDirHost) && is_dir($backupDirBase.$backupDirHost)) {
+                        $backupDateDirs = scandir($backupDirBase.$backupDirHost,1);
+                }
+        } else {
+                $backupDateDirs = scandir($backupDirBase.$backupDirHost,1);
+        }
 	// Get rid of . and .. from date dirs array
 	for ($i=0; $i<count($backupDateDirs); $i++) {
 		if ($backupDateDirs[$i] == "." || $backupDateDirs[$i] == "..") {

--- a/lib/settings-common.php
+++ b/lib/settings-common.php
@@ -190,7 +190,7 @@ function getVersionsCount($fileLoc,$fileName) {
 	$backupDirBase = str_replace("\\","/",dirname(__FILE__))."/../backups/";
 	$backupDirHost = isset($ftpSite) ? parse_url($ftpSite,PHP_URL_HOST) : "localhost";
         // check if folder exists if local before enumerating contents
-        if(!isset($ftpsite)) {
+        if(!isset($ftpSite)) {
                 if(file_exists($backupDirBase.$backupDirHost) && is_dir($backupDirBase.$backupDirHost)) {
                         $backupDateDirs = scandir($backupDirBase.$backupDirHost,1);
                 }


### PR DESCRIPTION
When the local backup folder is missing it was causing the following php warning

> PHP Stack trace:
> PHP   1. {main}() /var/www/html/ice/lib/file-control.php:0
> PHP   2. getVersionsCount() /var/www/html/ice/lib/file-control.php:189
> PHP   3. scandir() /var/www/html/ice/lib/settings-common.php:190
> PHP Warning:  scandir(): (errno 2): No such file or directory in /var/www/html/ice/lib/settings-common.php on line 190

This patch should correct the warning, however it does not address any underlying cause regarding why the folder doesn't exist when the `getVersionsCount()` method is being called. 