### PR TITLE
Corrects some issues that caused the interface to hang

### DIFF
--- a/lib/file-control-xhr.php
+++ b/lib/file-control-xhr.php
@@ -512,7 +512,7 @@ if (!$error && $_GET['action']=="save") {
 // ==========
 
 if (!$error && $_GET['action']=="newFolder") {
-	if (!$demoMode && ($ftpSite || is_writable($docRoot.$fileLoc))) {
+	if (!$demoMode && (isset($ftpSite) || is_writable($docRoot.$fileLoc))) {
 		$updateFM = false;
 		// FTP
 		if (isset($ftpSite)) {
@@ -555,7 +555,7 @@ if (!$error && $_GET['action']=="move") {
 		$tgtDir = $docRoot.$fileLoc."/".$fileName;
 	}
 	if ($srcDir != $tgtDir && $fileLoc != "") {
-		if (!$demoMode && ($ftpSite || is_writable($srcDir))) {
+		if (!$demoMode && (isset($ftpSite) || is_writable($srcDir))) {
 			$updateFM = false;
 			// FTP
 			if (isset($ftpSite)) {
@@ -597,7 +597,7 @@ if (!$error && $_GET['action']=="move") {
 // ==================
 
 if (!$error && $_GET['action']=="rename") {
-	if (!$demoMode && ($ftpSite || is_writable($docRoot.$iceRoot.str_replace("|","/",strClean($_GET['oldFileName']))))) {
+	if (!$demoMode && (isset($ftpSite) || is_writable($docRoot.$iceRoot.str_replace("|","/",strClean($_GET['oldFileName']))))) {
 		$updateFM = false;
 		// FTP
 		if (isset($ftpSite)) {
@@ -871,7 +871,7 @@ if (!isset($ftpSite) && !$error && $_GET['action']=="getRemoteFile") {
 // =======================
 
 if (!$error && $_GET['action']=="perms") {
-	if (!$demoMode && ($ftpSite || is_writable($file))) {
+	if (!$demoMode && (isset($ftpSite) || is_writable($file))) {
 		$updateFM = false;
 		// FTP
 		if (isset($ftpSite)) {

--- a/lib/file-control-xhr.php
+++ b/lib/file-control-xhr.php
@@ -917,7 +917,7 @@ if (!isset($ftpSite) && !$error && $_GET['action']=="checkExists") {
 // ===================
 
 // No $filemtime yet? Get it now!
-if (!isset($filemtime)) {
+if (!isset($filemtime) && !is_dir($file)) {
 	$filemtime = $serverType=="Linux" ? filemtime($file) : "1000000";
 }
 // Set $timeStart, use 0 if not available
@@ -937,7 +937,7 @@ if (isset($ftpSite)) {
 } else {
 	$itemAbsPath = $file;
 	$itemPath = dirname($file);
-	$itemBytes = filesize($file);
+	$itemBytes = is_dir($file) ? null : filesize($file);
 	$itemType = (file_exists($file) ? (is_dir($file) ? "dir" : "file") : "unknown");
 	$itemExists = (file_exists($file) ? "true" : "false");
 }


### PR DESCRIPTION
Under the conditions where ICE coder was set to edit local files, it would 'hang' on certain file operations forcing the user to reload the interface to see the new change.  The intended action would be completed, but it would prevent further file/folder operations due to the appearance the last operation was not completed.

There were also warnings being issued as the script attempted file operations on folders. These have also been corrected.